### PR TITLE
Deterministic merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Supported input format is SubRip (`*.srt`) only, supported output formats are Su
 
 It should also be noted that SubRip format specification does not include subtitle positioning. Srtgears uses an unofficial extension `{\anX}` which may not be supported by all video players, or some players interpret the position values differently. [MPC-HC](https://mpc-hc.org/) has full support for it. In these cases the Sub Station Alpha output format is recommended (where the specification covers subtitle positioning / alignment).
 
+## Development
+
+To compile for testing, run the following command, which generates the command line tool as an executable called `./srtgears`.
+
+```
+go build cmd/srtgears/srtgears.go
+```
+
 ## Story
 
 Srtgears started as a 48-hour work created for the [Gopher Gala 2016](http://gophergala.com/) event. The initial version can be found [here](https://github.com/gophergala2016/srtgears). I was competing solo.

--- a/cmd/srtgears/srtgears.go
+++ b/cmd/srtgears/srtgears.go
@@ -7,11 +7,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/icza/srtgears"
-	"github.com/icza/srtgears/exec"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/udacity/srtgears"
+	"github.com/udacity/srtgears/exec"
 )
 
 var Version = "dev" // Srtgears version, filled by build

--- a/exec/executor.go
+++ b/exec/executor.go
@@ -11,11 +11,12 @@ package exec
 import (
 	"flag"
 	"fmt"
-	"github.com/icza/srtgears"
 	"io"
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/udacity/srtgears"
 )
 
 // Executor is a helper type of which you can execute subtitle transformations defined by a series of arguments.

--- a/subspack.go
+++ b/subspack.go
@@ -108,11 +108,11 @@ func (sp *SubsPack) Merge(sp2 *SubsPack) {
 	// Output container
 	merged := make([]*Subtitle, numSubs)
 
-	// Pointers for iteration
-	i, p1, p2 := 0, 0, 0
+	// Indicies for iteration
+	p1, p2 := 0, 0
 
-	// Step through to do a stable merge sort
-	for i < numSubs {
+	// Step through to do a stable merge
+	for i := 0; i < numSubs; i++ {
 		if p1 < l1 && sp.Subs[p1].TimeIn <= sp2.Subs[p2].TimeIn {
 			merged[i] = sp.Subs[p1]
 			p1++
@@ -120,7 +120,6 @@ func (sp *SubsPack) Merge(sp2 *SubsPack) {
 			merged[i] = sp2.Subs[p2]
 			p2++
 		}
-		i++
 	}
 
 	// Write results back into sp

--- a/subspack.go
+++ b/subspack.go
@@ -97,11 +97,35 @@ func (sp *SubsPack) Concatenate(sp2 *SubsPack, secPartStart time.Duration) {
 //
 // Useful if 2 different subtitles are to be displayed at the same time, e.g. 2 different languages.
 func (sp *SubsPack) Merge(sp2 *SubsPack) {
-	// Append:
-	sp.Subs = append(sp.Subs, sp2.Subs...)
-
-	// And sort
+	// Make sure inputs are properly ordered
 	sp.Sort()
+	sp2.Sort()
+
+	// Guards to prevent null pointer access
+	l1 := len(sp.Subs)
+	numSubs := l1 + len(sp2.Subs)
+
+	// Output container
+	merged := make([]*Subtitle, numSubs)
+
+	// Pointers for iteration
+	i, p1, p2 := 0, 0, 0
+
+	// Step through to do a stable merge sort
+	for i < numSubs {
+		if p1 < l1 && sp.Subs[p1].TimeIn <= sp2.Subs[p2].TimeIn {
+			merged[i] = sp.Subs[p1]
+			p1++
+		} else {
+			merged[i] = sp2.Subs[p2]
+			p2++
+		}
+		i++
+	}
+
+	// Write results back into sp
+	sp.Subs = make([]*Subtitle, numSubs)
+	copy(sp.Subs, merged)
 }
 
 // Split splits this SubsPack into 2 at the specified time.


### PR DESCRIPTION
Rewrites the naive merge to be stable and preserve relative ordering in cases of matching timestamps.

cc/ @tauon 